### PR TITLE
.gitignore: ignore .DS_Store and Thumbs.db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Godot-specific ignores
 .import/
 export.cfg
@@ -7,3 +6,7 @@ export_presets.cfg
 # Mono-specific ignores
 .mono/
 data_*/
+
+# OS-specific ignores
+.DS_Store
+Thumbs.db


### PR DESCRIPTION
.DS_Store und Thumbs.db Dateien werden von MacOS bzw Windows automatisch generiert und haben nichts mit dem Arbeitsprojekt zu tun