### PR TITLE
Create a simple workflow to lint the code

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,37 @@
+name: Lint
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the main branch
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  lint:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+      # set-up python (required for godot-gdscript-toolkit)
+      - name: Setup Python
+        uses: actions/setup-python@v3.1.2
+
+      # Install godot-gdscript-toolkit
+      - name: Install godot-gdscript-toolkit
+        run: pip3 install 'gdtoolkit==3.*'
+
+      # lint all gd files
+      - name: Lint all the gd files with gdtoolkit
+        run: gdlint game/
+
+      - name: Suggest changes with gdformat
+        run: gdformat -d game/


### PR DESCRIPTION
Das ist ein einfacher Workflow, der automatisch alle GD-Skript-Dateien lintet.

Dieser PR basiert auf dem Vorschlag in #10 