### PR TITLE
Text eol conversion. Force LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf


### PR DESCRIPTION
# Description
Added one rule to .gitattributes. To ensure all text files have normalized LF line endings
Windows likes to save text files with CRLF line endings

Related to no issue

## Type of change
- [x] Tooling (non breaking change that adds funktionality to the workflow)

## Environment
- OS: Windows

# Checklist
- [x] I have perfomed a self-review of my code