### PR TITLE
Allow games to easily store things and store play time and scores

### DIFF
--- a/game/games/flappybird/Player.gd
+++ b/game/games/flappybird/Player.gd
@@ -26,7 +26,7 @@ func _physics_process(delta):
 		return
 
 	if position.y > 130:
-		GameManager.end_game(END_MESSAGE % score)
+		GameManager.end_game(END_MESSAGE % score, score)
 		return
 
 	if Input.is_action_just_pressed("flap"):
@@ -89,4 +89,4 @@ func _on_Hitbox_body_entered(body):
 	if body.name == "Wall":
 		# here would come a death sound when player dies ($Sound_GameEnd)
 		# when the gamemanager is evolved enough to handle that, ill add it
-		GameManager.end_game(END_MESSAGE % score)
+		GameManager.end_game(END_MESSAGE % score, score)

--- a/game/games/testgame/README.md
+++ b/game/games/testgame/README.md
@@ -1,12 +1,12 @@
 # How to add you own Minigame - A Step-by-step Guide
 
 ## 1. Choose a folder for your minigame
-All files related to your game only go into a folder inside `res://games/` with a random name you choose. You shouldn't rename it after the game is first merged.<br>
+All files related to your game only go into a folder inside `res://games/` with a random name you choose. You shouldn't rename it after the game is first merged.  
 There are no rules what to call it. A good idea is to use your name and the name of your game (ex. `asecondguy_assimilator`) to avoid any accidental collisions.
 
 ## 2. Make a game.cfg
 The game.cfg file resides in your minigame folder. It defines how your game is loaded and displayed in the game selection menu.
-You can find all relevant keys in this document.<br>
+You can find all relevant keys in this document.  
 If you are unsure copy the game.cfg from the testgame and change the values to your need.
 It will always contain all required and optional settings clearly marked.
 
@@ -19,23 +19,23 @@ It will always contain all required and optional settings clearly marked.
 
 # game.cfg keys
 * Section: `game`
-  * Choose a memorable name<br>
+  * Choose a memorable name  
     `name="Balloon pop"`
-  * Description supports bbcode. Say what your game is about.<br>
+  * Description supports bbcode. Say what your game is about.  
     `desc="Pop the balloons of the right [color=blue]color[/color]"`  
-  * These paths are relative to the game folder.<br>
-    `main_scene="balloonPop.tscn"`<br>
+  * These paths are relative to the game folder.  
+    `main_scene="balloonPop.tscn"`  
     `icon="balloon.png"`
-  * Version has no effect. But it might be shown in debug menus.<br>
+  * Version has no effect. But it might be shown in debug menus.  
     `version="1.0"`
-  * Put your name here. Has no effect.<br>
+  * Put your name here. Has no effect.  
     `creator="ASecondGuy"`
 
 # Useful functions
-* **`end_game(message: String = "", score = null)`**<br>
-  Ends the game and displays the message. This behaviour will change in the future.<br>
-  If your game has a score representet by a comperable constant type, then pass it as `score`.<br>
+* **`end_game(message: String = "", score = null)`**  
+  Ends the game and displays the message. This behaviour will change in the future.  
+  If your game has a score representet by a comperable constant type, then pass it as `score`.  
   If the score is more complex you can even pass a Dictionary with a `"score"` key that has a comperable value and constant type.
 
-* **`load_game(game_cfg: ConfigFile)`**<br>
+* **`load_game(game_cfg: ConfigFile)`**  
   Loads the game specified by the config file.

--- a/game/games/testgame/README.md
+++ b/game/games/testgame/README.md
@@ -1,12 +1,12 @@
 # How to add you own Minigame - A Step-by-step Guide
 
 ## 1. Choose a folder for your minigame
-All files related to your game only go into a folder inside `res://games/` with a random name you choose. You shouldn't rename it after the game is first merged.  
-There are no rules what to call it. A good idea is to use your name and the name of your game (ex. `asecondguy_assimilator`) to avoid any accidental collisions.  
+All files related to your game only go into a folder inside `res://games/` with a random name you choose. You shouldn't rename it after the game is first merged.<br>
+There are no rules what to call it. A good idea is to use your name and the name of your game (ex. `asecondguy_assimilator`) to avoid any accidental collisions.
 
 ## 2. Make a game.cfg
-The game.cfg file resides in your minigame folder. It defines how your game is loaded and displayed in the game selection menu.  
-You can find all relevant keys in this document.  
+The game.cfg file resides in your minigame folder. It defines how your game is loaded and displayed in the game selection menu.
+You can find all relevant keys in this document.<br>
 If you are unsure copy the game.cfg from the testgame and change the values to your need.
 It will always contain all required and optional settings clearly marked.
 
@@ -14,26 +14,28 @@ It will always contain all required and optional settings clearly marked.
 * GameManager is always available in every script and has useful functions(like `end_game()`). A list of these functions can be found in this document or the full list with all functions in [this README](../../menu/README.md)
 * Don't add `Autoload` scripts. They are loaded on startup and run all the time so it is bad practice to use one in a minigame.
 * The scene you defined in `game.cfg` will be loaded with `get_tree().change_scene()`. So It'll work like it is the main scene.
-* To return to the game selection use `GameManager.end_game("This is the end message")`
+* To return to the game selection use `GameManager.end_game("This is the end message", score)`
 * The PauseMenu will work immediately. It will pause the game using `get_tree().paused` so make sure none of your gameplay nodes have the pause mode on PROCESS.
 
 # game.cfg keys
 * Section: `game`
-  * Choose a memorable name  
-    `name="Balloon pop"`  
-  * Description supports bbcode. Say what your game is about.  
+  * Choose a memorable name<br>
+    `name="Balloon pop"`
+  * Description supports bbcode. Say what your game is about.<br>
     `desc="Pop the balloons of the right [color=blue]color[/color]"`  
-  * These paths are relative to the game folder.  
-    `main_scene="balloonPop.tscn"`  
-    `icon="balloon.png"`  
-  * Version has no effect. But it might be shown in debug menus.  
-    `version="1.0"`  
-  * Put your name here. Has no effect.  
-    `creator="ASecondGuy"`  
+  * These paths are relative to the game folder.<br>
+    `main_scene="balloonPop.tscn"`<br>
+    `icon="balloon.png"`
+  * Version has no effect. But it might be shown in debug menus.<br>
+    `version="1.0"`
+  * Put your name here. Has no effect.<br>
+    `creator="ASecondGuy"`
 
 # Useful functions
-* **`end_game(message: String="", _status=null)`**  
-  Ends the game and displays the message. This behaviour will change in the future.  
-  `_status` isn't used at the moment. It is meant for the score the player achived.  
-* `load_game(game_cfg: ConfigFile)`  
-  Loads the game specified by the config file.  
+* **`end_game(message: String = "", score = null)`**<br>
+  Ends the game and displays the message. This behaviour will change in the future.<br>
+  If your game has a score representet by a comperable constant type, then pass it as `score`.<br>
+  If the score is more complex you can even pass a Dictionary with a `"score"` key that has a comperable value and constant type.
+
+* **`load_game(game_cfg: ConfigFile)`**<br>
+  Loads the game specified by the config file.

--- a/game/games/testgame/balloonPop.gd
+++ b/game/games/testgame/balloonPop.gd
@@ -1,9 +1,8 @@
-# warning-ignore-all:return_value_discarded
 extends MarginContainer
 
-const END_MESSAGE := "You got %s points!"
+const END_MESSAGE := "You got %d points!"
 const COLOR_MESSAGE := "Pop a %s balloon"
-const STATUS_MESSAGE := "You'r in stage %s/10 and have %s points!"
+const STATUS_MESSAGE := "You're in stage %d/10 and have %s points! (Your highscore is: %d)"
 
 var balloon_scene := preload("res://games/testgame/balloon.tscn")
 
@@ -31,6 +30,13 @@ onready var _particles := $VBoxContainer/Particles2D
 
 func _ready():
 	_rng.randomize()
+	### start --- Data saving demo ---
+	# var data = GameManager.get_game_data()
+	# print("Loaded: ", data["num"] if "num" in data else null)
+	# data["num"] = _rng.randi()
+	# print("Saved: ", data["num"])
+	# GameManager.end_game("", -data["num"])  # end game here to quickly test saving
+	#### end  --- Data saving demo ---
 	start()
 
 
@@ -107,10 +113,13 @@ func _delete_all():
 # timer leaves a little time between stage end and the next stage start or game end
 func _on_RespawnTimer_timeout():
 	if stage >= 10:
-		GameManager.end_game(END_MESSAGE % points)
+		GameManager.end_game(END_MESSAGE % points, points)
 		return
 	_spawn()
 
 
 func _update_status():
-	_status_label.text = STATUS_MESSAGE % [stage, points]
+	var high_score = GameManager.get_high_score()
+	if high_score == null:
+		high_score = points
+	_status_label.text = STATUS_MESSAGE % [stage, points, max(points, high_score)]

--- a/game/games/testgame/balloonPop.gd
+++ b/game/games/testgame/balloonPop.gd
@@ -81,8 +81,8 @@ func _spawn_color(color: Color):
 	b.rect_position.y = _rng.randf_range(0, max_pos.y)
 
 	# signals
-	b.connect("pressed", self, "_on_destroy", [color, b])
-	b.connect("pressed", b, "queue_free")
+	GameManager.handle_error(b.connect("pressed", self, "_on_destroy", [color, b]))
+	GameManager.handle_error(b.connect("pressed", b, "queue_free"))
 	# modulate
 	b.self_modulate = color
 
@@ -119,7 +119,7 @@ func _on_RespawnTimer_timeout():
 
 
 func _update_status():
-	var high_score = GameManager.get_high_score()
-	if high_score == null:
-		high_score = points
-	_status_label.text = STATUS_MESSAGE % [stage, points, max(points, high_score)]
+	var highscore = GameManager.get_highscore()["score"]
+	if highscore == null:
+		highscore = points
+	_status_label.text = STATUS_MESSAGE % [stage, points, max(points, highscore)]

--- a/game/menu/README.md
+++ b/game/menu/README.md
@@ -4,11 +4,11 @@
 If in the code a `game_id` is mentioned, this is the name of the folder where the game is in.
 
 ## GameManager
-The GameManager keeps track of all minigames and starts/stops them when needed.<br>
+The GameManager keeps track of all minigames and starts/stops them when needed.  
 It also has a rudimentary game selection menu that uses the GameDisplays.
 
 ## GameDisplay
-Is used my the GameManagers game menu to show what the game is about.<br>
+Is used my the GameManagers game menu to show what the game is about.  
 It has a button to load the game & a popup for more detailed infos but no logic beyond that.
 
 ## PauseMenu
@@ -18,62 +18,62 @@ It uses `_input()` as a trigger so it won't interfere with other UI or gameplay.
 # API
 ## GameManager
 
-* **`load_game(game_cfg: ConfigFile)`**<br>
+* **`load_game(game_cfg: ConfigFile)`**  
   Loads the game specified by the config file.
 
-* **`end_game(message: String = "", score = null)`**<br>
-  Ends the game and displays `message`. This behaviour will change in the future.<br>
+* **`end_game(message: String = "", score = null)`**  
+  Ends the game and displays `message`. This behaviour will change in the future.  
   `score` is the score the player achived while playing the game. Leave it out if the game has no scores.
 
-* **`handle_error(err: int, err_msg: String = "", formats: Array = [])`**<br>
-  Prints an error if `err != OK`.<br>
-  If `err_msg` is specified `"Error {err} - {err_msg % formats}"` will be printed.<br>
+* **`handle_error(err: int, err_msg: String = "", formats: Array = [])`**  
+  Prints an error if `err != OK`.  
+  If `err_msg` is specified `"Error {err} - {err_msg % formats}"` will be printed.  
   If no `err_msg` is specified `"Error {err}"` will be printed.
 
-* **`get_game_data()`**<br>
+* **`get_game_data()`**  
   Only use this while in a game.
   This returns a Dictionary in which games can write data. This will be saved to disk when the game ends.
   Use this as persistent storage.
 
-* **`save_game_data()`**<br>
+* **`save_game_data()`**  
   Only use this while in a game.
   This will be automatically called in `end_game()`.
   This saves the changes made to the Dictionary returned by `get_game_data()`
 
-* **`get_current_player()`**<br>
+* **`get_current_player()`**  
   This should in future return the name of the current player as String. Currently it just returns "p".
 
-* **`get_last_played(game_id = null)`**<br>
+* **`get_last_played(game_id = null)`**  
   Only use this while in a game or specify game_id.
   Get the time the player returned by `get_current_player()` last played a game.
 
-* **`get_played_time(game_id = null)`**<br>
+* **`get_played_time(game_id = null)`**  
   Only use this while in a game or specify game_id.
   Get the time the player returned by `get_current_player()` already played a game.
 
-* **`get_highscore(game_id = null)`**<br>
+* **`get_highscore(game_id = null)`**  
   Only use this while in a game or specify game_id.
-  Get the highscore of the player returned by `get_current_player()` in the game.<br>
+  Get the highscore of the player returned by `get_current_player()` in the game.  
   The returned Dictionary has a "score" key, that contains the real score.
 
-* **`_build_menu()`**<br>
+* **`_build_menu()`**  
   Creates a menu using GameDisplays for the cached `game.cfg` files in `_games`
 
-* **`_find_and_load_games()`**<br>
-  Searches every folder inside "res://games/" for files called `game.cfg` and caches them in `_games` using `_load_game_cfg_file()`.<br>
+* **`_find_and_load_games()`**  
+  Searches every folder inside "res://games/" for files called `game.cfg` and caches them in `_games` using `_load_game_cfg_file()`.  
   `_games` is cleared at the start.
 
-* **`_load_game_cfg_file(folder_name: String)`**<br>
-  Loads any config file into `_games`.<br>
+* **`_load_game_cfg_file(folder_name: String)`**  
+  Loads any config file into `_games`.  
   Any valid .cfg will be loaded. There are no checks to prevent incorect data from loading.
 
 
 ## GameDisplay
-* signal **`pressed(game_file)`**<br>
-  Is emitted when any load buttons of the display are pressed.<br>
+* signal **`pressed(game_file)`**  
+  Is emitted when any load buttons of the display are pressed.  
   `game_file` is the config used when setup was called.
 
-* **`setup(game_cfg: ConfigFile)`**<br>
+* **`setup(game_cfg: ConfigFile)`**  
   Loads the data from the given `game.cfg` into the correct labels.
 
 ## PauseMenu

--- a/game/menu/README.md
+++ b/game/menu/README.md
@@ -1,12 +1,15 @@
 # Information for Contributers
 
+## Game-Id
+If in the code a `game_id` is mentioned, this is the name of the folder where the game is in.
+
 ## GameManager
-The GameManager keeps track of all minigames and starts/stops them when needed.  
-It also has a rudimentary game selection menu that uses the GameDisplays.  
+The GameManager keeps track of all minigames and starts/stops them when needed.<br>
+It also has a rudimentary game selection menu that uses the GameDisplays.
 
 ## GameDisplay
-Is used my the GameManagers game menu to show what the game is about.  
-It has a button to load the game & a popup for more detailed infos but no logic beyond that.  
+Is used my the GameManagers game menu to show what the game is about.<br>
+It has a button to load the game & a popup for more detailed infos but no logic beyond that.
 
 ## PauseMenu
 The PauseMenu is autoloaded like GameManager. It will pause the game using `get_tree().paused`.  
@@ -15,31 +18,63 @@ It uses `_input()` as a trigger so it won't interfere with other UI or gameplay.
 # API
 ## GameManager
 
-* **`load_game(game_cfg: ConfigFile)`**  
+* **`load_game(game_cfg: ConfigFile)`**<br>
   Loads the game specified by the config file.
 
-* **`end_game(message:String="", _status=null)`**  
-  Ends the game and displays `message`. This behaviour will change in the future.  
-  `_status` isn't used at the moment. It is meant for the score the player achived.  
+* **`end_game(message: String = "", score = null)`**<br>
+  Ends the game and displays `message`. This behaviour will change in the future.<br>
+  `score` is the score the player achived while playing the game. Leave it out if the game has no scores.
 
-* **`_build_menu()`**  
-  Creates a menu using GameDisplays for the cached `game.cfg` files in `_games`  
+* **`handle_error(err: int, err_msg: String = "", formats: Array = [])`**<br>
+  Prints an error if `err != OK`.<br>
+  If `err_msg` is specified `"Error {err} - {err_msg % formats}"` will be printed.<br>
+  If no `err_msg` is specified `"Error {err}"` will be printed.
 
-* **`_find_games()`**   
-  Searches every folder inside "res://games/" for files called `game.cfg` and caches them in `_games` using `_load_game_cfg_file()`.  
-  `_games` is cleared at the start.  
+* **`get_game_data()`**<br>
+  Only use this while in a game.
+  This returns a Dictionary in which games can write data. This will be saved to disk when the game ends.
+  Use this as persistent storage.
 
-* **`_load_game_cfg_file(path: String)`**  
-    Loads any config file into `_games`.  
-    Any valid .cfg will be loaded. There are no checks to prevent incorect data from loading.  
+* **`save_game_data()`**<br>
+  Only use this while in a game.
+  This will be automatically called in `end_game()`.
+  This saves the changes made to the Dictionary returned by `get_game_data()`
+
+* **`get_current_player()`**<br>
+  This should in future return the name of the current player as String. Currently it just returns "p".
+
+* **`get_last_played(game_id = null)`**<br>
+  Only use this while in a game or specify game_id.
+  Get the time the player returned by `get_current_player()` last played a game.
+
+* **`get_played_time(game_id = null)`**<br>
+  Only use this while in a game or specify game_id.
+  Get the time the player returned by `get_current_player()` already played a game.
+
+* **`get_highscore(game_id = null)`**<br>
+  Only use this while in a game or specify game_id.
+  Get the highscore of the player returned by `get_current_player()` in the game.<br>
+  The returned Dictionary has a "score" key, that contains the real score.
+
+* **`_build_menu()`**<br>
+  Creates a menu using GameDisplays for the cached `game.cfg` files in `_games`
+
+* **`_find_and_load_games()`**<br>
+  Searches every folder inside "res://games/" for files called `game.cfg` and caches them in `_games` using `_load_game_cfg_file()`.<br>
+  `_games` is cleared at the start.
+
+* **`_load_game_cfg_file(folder_name: String)`**<br>
+  Loads any config file into `_games`.<br>
+  Any valid .cfg will be loaded. There are no checks to prevent incorect data from loading.
+
 
 ## GameDisplay
-* signal **`pressed(game_file)`**  
-    Is emitted when any load buttons of the display are pressed.  
-    `game_file` is the config used when setup was called.  
+* signal **`pressed(game_file)`**<br>
+  Is emitted when any load buttons of the display are pressed.<br>
+  `game_file` is the config used when setup was called.
 
-* **`setup(game_cfg: ConfigFile)`**  
-    Loads the data from the given `game.cfg` into the correct labels.  
+* **`setup(game_cfg: ConfigFile)`**<br>
+  Loads the data from the given `game.cfg` into the correct labels.
 
 ## PauseMenu
 * signal **`pause_menu_opened`**  

--- a/game/menu/data_manager.gd
+++ b/game/menu/data_manager.gd
@@ -1,0 +1,128 @@
+extends Node
+
+const SAVE_FILE_DIR = "user://savefiles/%s/%s/"
+
+## type of _game_data_cache: Dictionary[String, Dictionary]
+##                                  (file name) (the data)
+var _game_data_cache := {}  # NEVER MODIFY THIS, IF YOU DON'T KNOW WHAT YOU ARE DOING!
+
+
+## Save data to a file for the given game.
+## This is a private function, don't use this in a game
+func _save_data(player: String, file_name: String, data, game_id: String) -> int:
+	var cache_key := player + "/" + game_id + "/" + file_name
+	var directory := SAVE_FILE_DIR % [player, game_id]
+	var err := Directory.new().make_dir_recursive(directory)
+	if err != OK:
+		return err
+	if not cache_key in _game_data_cache:
+		return OK
+	_game_data_cache[cache_key] = data
+	var file := File.new()
+	err = file.open(directory + file_name + ".json", File.WRITE)
+	if err != OK:
+		return err
+	file.store_string(JSON.print(_game_data_cache[cache_key]))
+	file.close()
+	return OK
+
+
+## Load data from a file or _game_data_cache and return the data for the game.
+## If something doesn't exist an empty Dictionary is returned, which is put in
+## the correct location in the _game_data_cache Dictionary.
+## This is a private function, don't use this in a game.
+func _load_data(player: String, file_name: String, game_id: String) -> Dictionary:
+	var cache_key := "%s/%s/%s" % [player, game_id, file_name]
+	if cache_key in _game_data_cache:
+		return _game_data_cache[cache_key]
+
+	var directory := SAVE_FILE_DIR % [player, game_id]
+	GameManager.handle_error(Directory.new().make_dir_recursive(directory))
+
+	_game_data_cache[cache_key] = {}  # populate with default
+	# read saved data from a file
+	var file := File.new()
+	var err := file.open(directory + file_name + ".json", File.READ)
+
+	if err != OK or not file.is_open():
+		return _game_data_cache[cache_key]
+
+	var content = file.get_as_text()
+	file.close()
+
+	var parse_result = JSON.parse(content)
+	if not parse_result.error:
+		# put contents from file in the cache
+		_game_data_cache[cache_key] = parse_result.result
+
+	return _game_data_cache[cache_key]
+
+
+## Get the game data for the current player and the current game.
+## To save data. Just modify the returned Dictionary and call save_game_data().
+func get_game_data(player: String, game_id: String) -> Dictionary:
+	return _load_data(player, "game_data", game_id)
+
+
+## Save the changes to the Dictionary returned by get_game_data()
+## This method is automatically called when a game ends.
+func save_game_data(player: String, game_id: String):
+	GameManager.handle_error(
+		_save_data(player, "game_data", _load_data(player, "game_data", game_id), game_id),
+		"Saving game data for player %s and game %s failed.",
+		[player, game_id]
+	)
+
+
+## Handle data for the game that ended.
+func game_ended(player: String, game_id: String, start_time: int, score: int):
+	save_game_data(player, game_id)
+
+	var data = _load_data(player, "game_meta_data", game_id)
+
+	data["last_played"] = OS.get_unix_time()
+
+	if not "played_time" in data:
+		data["played_time"] = 0
+	data["played_time"] += (OS.get_ticks_msec() - start_time) / 1000.0
+
+	if score != null:
+		if not "scores" in data:
+			data["scores"] = []
+		data["scores"].append([score, data["last_played"]])
+		data["scores"].sort()
+
+	GameManager.handle_error(_save_data(player, "game_meta_data", data, game_id))
+
+
+## Get the high_score of the player for the game.
+func get_high_score(player: String, game_id: String):
+	var data = _load_data(player, "game_meta_data", game_id)
+
+	if not "scores" in data:
+		return null
+
+	if data["scores"].size() == 0:
+		return null
+
+	return data["scores"][-1][0]
+
+
+## Get time the player played the game.
+func get_played_time(player: String, game_id: String) -> float:
+	var data = _load_data(player, "game_meta_data", game_id)
+	if not "played_time" in data:
+		return 0.0
+	return data["played_time"]
+
+
+## Get the time the player played the game last time.
+func get_last_played(player: String, game_id: String):
+	var data = _load_data(player, "game_meta_data", game_id)
+	if not "last_played" in data:
+		return null
+	var dt = OS.get_datetime_from_unix_time(data["last_played"])
+	return (
+		"%04d-%02d-%02d %02d:%02d:%02d UTC"
+		% [dt["year"], dt["month"], dt["day"], dt["hour"], dt["minute"], dt["second"]]
+	)

--- a/game/menu/data_manager.gd
+++ b/game/menu/data_manager.gd
@@ -86,7 +86,7 @@ class ScoreSorter:
 
 
 ## Handle data for the game that ended.
-func game_ended(player: String, game_id: String, start_time: int, score: Dictionary):
+func game_ended(player: String, game_id: String, start_time, score: Dictionary):
 	save_game_data(player, game_id)
 
 	var data = _load_data(player, "game_meta_data", game_id)
@@ -95,14 +95,15 @@ func game_ended(player: String, game_id: String, start_time: int, score: Diction
 
 	data["last_played"] = current_time
 
-	if not "played_time" in data:
-		data["played_time"] = 0
-	data["played_time"] += (OS.get_ticks_msec() - start_time) / 1000.0
+	if start_time != null:
+		if not "played_time" in data:
+			data["played_time"] = 0
+		data["played_time"] += (OS.get_ticks_msec() - start_time) / 1000.0
 
 	if score != null:
 		if not "score" in score:
 			push_error("No 'score' in score Dictionary.")
-		else:
+		elif score["score"] != null:
 			score["_time"] = current_time
 			if not "scores" in data:
 				data["scores"] = []

--- a/game/menu/gamedisplay.gd
+++ b/game/menu/gamedisplay.gd
@@ -46,6 +46,14 @@ func disable():
 	_load_btn_dialog.disabled = true
 
 
+func format_date(unix_time: int):
+	var dt = OS.get_datetime_from_unix_time(unix_time)
+	return (
+		"%04d-%02d-%02d %02d:%02d:%02d UTC"
+		% [dt["year"], dt["month"], dt["day"], dt["hour"], dt["minute"], dt["second"]]
+	)
+
+
 func update_text():
 	var game_id = game_file.get_meta("folder_name")
 	var text = game_file.get_value("game", "desc")
@@ -54,13 +62,19 @@ func update_text():
 
 	var last_played = GameManager.get_last_played(game_id)
 	if last_played != null:
-		text += "\nLast played: %s" % last_played
+		text += "\nLast played: %s" % format_date(last_played)
 
-	var high_score = GameManager.get_high_score(game_id)
-	if high_score != null:
-		text += "\nHighscore: %d" % high_score
+	var highscore_dict = GameManager.get_highscore(game_id)
+	if highscore_dict["score"] != null:
+		if "_time" in highscore_dict:
+			text += (
+				"\nHighscore: %s (%s)"
+				% [highscore_dict["score"], format_date(highscore_dict["_time"])]
+			)
+		else:
+			text += "\nHighscore: %s" % highscore_dict["score"]
 
-	# update the high_score displayed in $VBoxContainer/RichTextLabel
+	# update the highscore displayed in $VBoxContainer/RichTextLabel
 	$VBoxContainer/RichTextLabel.bbcode_text = text
 
 

--- a/game/menu/gamemanager.gd
+++ b/game/menu/gamemanager.gd
@@ -90,16 +90,20 @@ func get_played_time(game_id = null) -> float:
 	return _data_manager.get_played_time(get_current_player(), game_id)
 
 
-## Get the high_score of the current player for the currently running game.
-func get_high_score(game_id = null):
+## Get the highscore of the current player for the currently running game.
+## The score you would expect is available under the "score" key in the returned Dictionary.
+func get_highscore(game_id = null) -> Dictionary:
 	game_id = _last_loaded_game if game_id == null else game_id
 	if not game_id:  # game_id should be the folder_name, not null or ""
-		return null
-	return _data_manager.get_high_score(get_current_player(), game_id)
+		return {"score": null}
+	var highscore = _data_manager.get_highscore(get_current_player(), game_id)
+	if highscore == null:
+		return {"score": null}
+	return highscore
 
 
-# return to the level select
-func end_game(message := "", score = null, _status = null):
+##_ return to the level select
+func end_game(message := "", score = null):
 	var err = get_tree().change_scene("res://menu/emptySzene.tscn")
 	if err != OK:
 		prints("Error", err)
@@ -108,6 +112,9 @@ func end_game(message := "", score = null, _status = null):
 	_main.show()
 
 	assert(_last_loaded_game != null)  # should always be set here
+
+	if not score is Dictionary:
+		score = {"score": score}
 
 	_data_manager.game_ended(get_current_player(), _last_loaded_game, _started_playing_game, score)
 

--- a/game/menu/gamemanager.gd
+++ b/game/menu/gamemanager.gd
@@ -1,28 +1,41 @@
 extends Node
 
-var last_loaded_game
+## first %s is folder_name (same as game_id)
+## second %s is the file path relative to the game folder
+const GAME_FILE = "res://games/%s/%s"
 
-var _games = []
+var _games := {}  # type: Dictionary[String, ConfigFile]
+var _game_displays := {}  # type: Dictionary[String, gamedisplay]
+
 var _preview_scene := preload("res://menu/gamedisplay.tscn")
+var _last_loaded_game = null
+var _started_playing_game: int = 0
 
 onready var _grid := $mainmenu/ScrollContainer/GridContainer
 onready var _main := $mainmenu
+onready var _data_manager = load("res://menu/data_manager.gd").new()
 
 
 func _ready():
-	_find_games()
+	_find_and_load_games()
 	_build_menu()
 
 
 func load_game(game_cfg: ConfigFile):
+	_last_loaded_game = game_cfg.get_meta("folder_name")
+	_started_playing_game = OS.get_ticks_msec()
 	# load the games main scene
-	var folder = game_cfg.get_meta("folder_path")
-	var main = game_cfg.get_value("game", "main_scene")
-	var scene = load(folder + main)
-
+	var scene_path := (
+		GAME_FILE
+		% [
+			game_cfg.get_meta("folder_name"),
+			game_cfg.get_value("game", "main_scene"),
+		]
+	)
+	var scene = load(scene_path)
 	if scene == null:
 		# TODO: Error handling could be better
-		prints("Error: Game should specify correct main_scene, but was: ", folder, main)
+		prints("Error: Game should specify correct main_scene, but was: ", scene_path)
 		return ERR_FILE_BAD_PATH
 
 	var err := get_tree().change_scene_to(scene)
@@ -34,17 +47,77 @@ func load_game(game_cfg: ConfigFile):
 	return OK
 
 
+func handle_error(err: int, err_msg: String = "", formats: Array = []) -> void:
+	if err == OK:
+		return
+	if err_msg == "":
+		push_error("Error %s" % err)
+		return
+	if formats:
+		err_msg = err_msg % formats
+	push_error("Error %s - %s" % [err, err_msg])
+
+
+## Save the changes to the Dictionary returned by get_game_data()
+## This method is automatically called when a game ends.
+func save_game_data():
+	assert(_last_loaded_game != null)  # this should only be called if _last_loaded_game is set
+	_data_manager.save_game_data(get_current_player(), _last_loaded_game)
+
+
+## Get the game data for the current player and the current game.
+## To save data. Just modify the returned Dictionary and call save_game_data().
+func get_game_data() -> Dictionary:
+	assert(_last_loaded_game != null)
+	return _data_manager.get_game_data(get_current_player(), _last_loaded_game)
+
+
+func get_current_player() -> String:
+	return "p"  # in future add here more logic
+
+
+## Get the time the current player played the currently running game last.
+func get_last_played(game_id = null):
+	game_id = _last_loaded_game if game_id == null else game_id
+	assert(game_id != null)
+	return _data_manager.get_last_played(get_current_player(), game_id)
+
+
+## Get time the current player played the currently running game.
+func get_played_time(game_id = null) -> float:
+	game_id = _last_loaded_game if game_id == null else game_id
+	assert(game_id != null)
+	return _data_manager.get_played_time(get_current_player(), game_id)
+
+
+## Get the high_score of the current player for the currently running game.
+func get_high_score(game_id = null):
+	game_id = _last_loaded_game if game_id == null else game_id
+	if not game_id:  # game_id should be the folder_name, not null or ""
+		return null
+	return _data_manager.get_high_score(get_current_player(), game_id)
+
+
 # return to the level select
-func end_game(message := "", _status = null):
+func end_game(message := "", score = null, _status = null):
 	var err = get_tree().change_scene("res://menu/emptySzene.tscn")
 	if err != OK:
 		prints("Error", err)
 		return
 
 	_main.show()
-	last_loaded_game = null
+
+	assert(_last_loaded_game != null)  # should always be set here
+
+	_data_manager.game_ended(get_current_player(), _last_loaded_game, _started_playing_game, score)
+
+	_game_displays[_last_loaded_game].update_text()
+
+	_last_loaded_game = null
+	_started_playing_game = 0
+
 	# this behavior is subject to change
-	if !message.empty():
+	if message:
 		OS.alert(message)
 
 
@@ -55,14 +128,15 @@ func _build_menu():
 	_main.show()
 
 	#making the buttons
-	for game in _games:
+	for game_id in _games.keys():
 		var display = _preview_scene.instance()
 		_grid.add_child(display)
-		display.setup(game)
+		display.setup(_games[game_id])
+		_game_displays[game_id] = display
 
 
-# go through every folder inside res://games/ and try to load the game.cfg into _games
-func _find_games():
+## go through every folder inside res://games/ and try to load the game.cfg into _games
+func _find_and_load_games():
 	_games.clear()
 	var dir = Directory.new()
 	if dir.open("res://games") == OK:
@@ -70,9 +144,7 @@ func _find_games():
 		var file_name = dir.get_next()
 		while file_name != "":
 			if dir.current_is_dir():
-				var game_path = "res://games/" + file_name + "/game.cfg"
-
-				var err := _load_game_cfg_file(game_path)
+				var err := _load_game_cfg_file(file_name)
 				if err != OK:
 					prints("Error loading game cfg:", err)
 
@@ -80,11 +152,11 @@ func _find_games():
 
 
 # load a config file into _games
-func _load_game_cfg_file(path: String) -> int:
-	var f := ConfigFile.new()
-	var err := f.load(path)
+func _load_game_cfg_file(folder_name: String) -> int:
+	var config := ConfigFile.new()
+	var err := config.load(GameManager.GAME_FILE % [folder_name, "game.cfg"])
 	if err != OK:
 		return err
-	f.set_meta("folder_path", path.get_base_dir() + "/")
-	_games.push_back(f)
+	config.set_meta("folder_name", folder_name)
+	_games[folder_name] = config
 	return OK

--- a/game/menu/pausemenu/pausemenu.gd
+++ b/game/menu/pausemenu/pausemenu.gd
@@ -31,6 +31,7 @@ func _input(event):
 
 func show():
 	_main.show()
+	GameManager.pause_game()
 	emit_signal("pause_menu_opened")
 	get_tree().paused = true
 	_update_menu()
@@ -40,6 +41,9 @@ func hide():
 	_main.hide()
 	emit_signal("pause_menu_closed")
 	get_tree().paused = false
+	var curr_game = GameManager.get_current_game()
+	if curr_game != null:
+		GameManager.game_started(curr_game.get_meta("folder_name"))
 
 
 func is_open():
@@ -47,24 +51,25 @@ func is_open():
 
 
 func _update_menu():
-	var game: ConfigFile = GameManager.last_loaded_game
+	var game: ConfigFile = GameManager.get_current_game()
 	# true if a game is loaded
-	var in_game: bool = is_instance_valid(game)
+	var in_game: bool = game != null
 
 	_reset_btn.visible = in_game
 	_quit_game_btn.visible = in_game
 
 
 func _on_restartbtn_pressed():
-	GameManager.load_game(GameManager.last_loaded_game)
+	var current_game = GameManager.get_current_game()
+	GameManager.load_game(current_game)
 	hide()
 
 
 func _on_quitgamebtn_pressed():
-	GameManager.end_game("")
+	GameManager.end_game("")  # TODO: save score here
 	hide()
 
 
 func _on_quittodesctopbtn_pressed():
-	GameManager.end_game("")
+	GameManager.end_game("")  # TODO: save score here
 	get_tree().quit()


### PR DESCRIPTION
This pr adds helper methods for easily storing things.

They are used for storing scores, play time and the time you last played. This data can be accessed by games with `GameManager.get_high_score()`, `GameManager.get_last_played()` and  `GameManager.get_played_time()`.

Games can easily store stuff too. They can just call `GameManager.get_game_data()` and then modify the returned dictionary. The changes will then be saved automatically saved when the game is ended.

To be future proof the pr also adds a `get_current_player()` method, which can be modified to return a player name. If this is done, all the storing functionality will still work.

example save data:
'~/.local/share/godot/app_userdata/Suffragium/savefiles/p/testgame/game_meta_data.json'
```json
{"last_played":1654971870,"played_time":42.159,"scores":[{"score":10,"_time":1654967221},{"score":7,"_time":1654967262}]}
```
'~/.local/share/godot/app_userdata/Suffragium/savefiles/p/testgame/game_data.json'
```json
{"num":1229874613}
```
