### PR TITLE
Make Minigame Framework more resistent

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf

--- a/game/menu/gamedisplay.gd
+++ b/game/menu/gamedisplay.gd
@@ -2,11 +2,15 @@ extends MarginContainer
 
 signal pressed(game_file)
 
-var game_file: ConfigFile
+class_name GameDisplay
 
+var game_file: ConfigFile
+var loadbtn: Button
+var loadbtn2: Button
 
 func setup(game_cfg: ConfigFile):
 	game_file = game_cfg
+	loadbtn2 = $VBoxContainer/loadbutton
 
 	$VBoxContainer/Label.text = game_cfg.get_value("game", "name")
 	$VBoxContainer/RichTextLabel.bbcode_text = game_cfg.get_value("game", "desc")
@@ -20,10 +24,10 @@ func setup(game_cfg: ConfigFile):
 
 	#setup of info Dialog
 	##setup buttons
-	$InfoButton.connect("pressed", $InfoDialog, "popup_centered_minsize", [Vector2(500, 250)])
-	var loadbtn = $InfoDialog.add_button("load")
-	loadbtn.connect("pressed", $InfoDialog, "hide")
-	loadbtn.connect("pressed", self, "_on_loadbutton_pressed")
+	_handle_error($InfoButton.connect("pressed", $InfoDialog, "popup_centered_minsize", [Vector2(500, 250)]))
+	loadbtn = $InfoDialog.add_button("load")
+	_handle_error(loadbtn.connect("pressed", $InfoDialog, "hide"))
+	_handle_error(loadbtn.connect("pressed", self, "_on_loadbutton_pressed"))
 	##setup text
 	$InfoDialog/Container/Label.text = game_cfg.get_value("game", "name")
 	$InfoDialog/Container/TextureRect.texture = icon
@@ -34,5 +38,15 @@ func setup(game_cfg: ConfigFile):
 	$InfoDialog/Container/descCont/Statslab.text = text
 
 
+func disable():
+	loadbtn.disabled = true
+	loadbtn2.disabled = true
+
+# TODO: Maybe put this somewhere more central for reuse or smth
+func _handle_error(err):
+	if err != OK:
+		prints("Error", err)
+		return
+
 func _on_loadbutton_pressed():
-	emit_signal("pressed", game_file)
+	emit_signal("pressed", game_file, self)

--- a/game/menu/gamedisplay.gd
+++ b/game/menu/gamedisplay.gd
@@ -2,15 +2,13 @@ class_name GameDisplay
 
 extends MarginContainer
 
-signal pressed(game_file)
-
 var game_file: ConfigFile
-var _load_btn_main: Button
-var _load_btn_dialog: Button
+onready var _load_btn_main: Button = $VBoxContainer/loadbutton
+onready var _load_btn_dialog: Button = $InfoDialog.add_button("load")
+
 
 func setup(game_cfg: ConfigFile):
 	game_file = game_cfg
-	_load_btn_main = $VBoxContainer/loadbutton
 
 	$VBoxContainer/Label.text = game_cfg.get_value("game", "name")
 	$VBoxContainer/RichTextLabel.bbcode_text = game_cfg.get_value("game", "desc")
@@ -24,8 +22,10 @@ func setup(game_cfg: ConfigFile):
 
 	#setup of info Dialog
 	##setup buttons
-	_handle_error($InfoButton.connect("pressed", $InfoDialog, "popup_centered_minsize", [Vector2(500, 250)]))
-	_load_btn_dialog = $InfoDialog.add_button("load")
+	_handle_error(
+		$InfoButton.connect("pressed", $InfoDialog, "popup_centered_minsize", [Vector2(500, 250)])
+	)
+
 	_handle_error(_load_btn_dialog.connect("pressed", $InfoDialog, "hide"))
 	_handle_error(_load_btn_dialog.connect("pressed", self, "_on_loadbutton_pressed"))
 	##setup text
@@ -42,11 +42,14 @@ func disable():
 	_load_btn_main.disabled = true
 	_load_btn_dialog.disabled = true
 
+
 # TODO: Maybe put this somewhere more central for reuse or smth
 func _handle_error(err):
 	if err != OK:
 		prints("Error", err)
 		return
 
+
 func _on_loadbutton_pressed():
-	emit_signal("pressed", game_file, self)
+	if GameManager.load_game(game_file)!=OK:
+		disable()

--- a/game/menu/gamedisplay.gd
+++ b/game/menu/gamedisplay.gd
@@ -1,16 +1,16 @@
+class_name GameDisplay
+
 extends MarginContainer
 
 signal pressed(game_file)
 
-class_name GameDisplay
-
 var game_file: ConfigFile
-var loadbtn: Button
-var loadbtn2: Button
+var _load_btn_main: Button
+var _load_btn_dialog: Button
 
 func setup(game_cfg: ConfigFile):
 	game_file = game_cfg
-	loadbtn2 = $VBoxContainer/loadbutton
+	_load_btn_main = $VBoxContainer/loadbutton
 
 	$VBoxContainer/Label.text = game_cfg.get_value("game", "name")
 	$VBoxContainer/RichTextLabel.bbcode_text = game_cfg.get_value("game", "desc")
@@ -25,9 +25,9 @@ func setup(game_cfg: ConfigFile):
 	#setup of info Dialog
 	##setup buttons
 	_handle_error($InfoButton.connect("pressed", $InfoDialog, "popup_centered_minsize", [Vector2(500, 250)]))
-	loadbtn = $InfoDialog.add_button("load")
-	_handle_error(loadbtn.connect("pressed", $InfoDialog, "hide"))
-	_handle_error(loadbtn.connect("pressed", self, "_on_loadbutton_pressed"))
+	_load_btn_dialog = $InfoDialog.add_button("load")
+	_handle_error(_load_btn_dialog.connect("pressed", $InfoDialog, "hide"))
+	_handle_error(_load_btn_dialog.connect("pressed", self, "_on_loadbutton_pressed"))
 	##setup text
 	$InfoDialog/Container/Label.text = game_cfg.get_value("game", "name")
 	$InfoDialog/Container/TextureRect.texture = icon
@@ -39,8 +39,8 @@ func setup(game_cfg: ConfigFile):
 
 
 func disable():
-	loadbtn.disabled = true
-	loadbtn2.disabled = true
+	_load_btn_main.disabled = true
+	_load_btn_dialog.disabled = true
 
 # TODO: Maybe put this somewhere more central for reuse or smth
 func _handle_error(err):

--- a/game/menu/gamemanager.gd
+++ b/game/menu/gamemanager.gd
@@ -12,7 +12,7 @@ func _ready():
 	_build_menu()
 
 
-func load_game(game_cfg: ConfigFile, display: GameDisplay):
+func load_game(game_cfg: ConfigFile):
 	# load the games main scene
 	var folder = game_cfg.get_meta("folder_path")
 	var main = game_cfg.get_value("game", "main_scene")
@@ -21,14 +21,14 @@ func load_game(game_cfg: ConfigFile, display: GameDisplay):
 	if scene == null:
 		# TODO: Error handling could be better
 		prints("Error: Game should specify correct main_scene, but was: ", folder, main)
-		display.disable()
-		return
+		return ERR_FILE_BAD_PATH
 
 	var err := get_tree().change_scene_to(scene)
 	if err != OK:
 		prints("Error", err)
-		return
+		return err
 	_main.hide()
+	return OK
 
 
 # return to the level select
@@ -53,9 +53,8 @@ func _build_menu():
 	#making the buttons
 	for game in _games:
 		var display = _preview_scene.instance()
-		display.setup(game)
-		display.connect("pressed", self, "load_game")
 		_grid.add_child(display)
+		display.setup(game)
 
 
 # go through every folder inside res://games/ and try to load the game.cfg into _games

--- a/game/menu/gamemanager.gd
+++ b/game/menu/gamemanager.gd
@@ -12,9 +12,17 @@ func _ready():
 	_build_menu()
 
 
-func load_game(game_cfg: ConfigFile):
+func load_game(game_cfg: ConfigFile, display: GameDisplay):
 	# load the games main scene
-	var scene = load(game_cfg.get_meta("folder_path") + game_cfg.get_value("game", "main_scene"))
+	var folder = game_cfg.get_meta("folder_path")
+	var main = game_cfg.get_value("game", "main_scene")
+	var scene = load(folder + main)
+
+	if scene == null:
+		# TODO: Error handling could be better
+		prints("Error: Game should specify correct main_scene, but was: ", folder, main)
+		display.disable()
+		return
 
 	var err := get_tree().change_scene_to(scene)
 	if err != OK:
@@ -25,7 +33,11 @@ func load_game(game_cfg: ConfigFile):
 
 # return to the level select
 func end_game(message := "", _status = null):
-	get_tree().change_scene("res://menu/emptySzene.tscn")
+	var err = get_tree().change_scene("res://menu/emptySzene.tscn")
+	if err != OK:
+		prints("Error", err)
+		return
+
 	_main.show()
 	# this behavior is subject to change
 	if !message.empty():

--- a/game/project.godot
+++ b/game/project.godot
@@ -8,6 +8,16 @@
 
 config_version=4
 
+_global_script_classes=[ {
+"base": "MarginContainer",
+"class": "GameDisplay",
+"language": "GDScript",
+"path": "res://menu/gamedisplay.gd"
+} ]
+_global_script_class_icons={
+"GameDisplay": ""
+}
+
 [application]
 
 config/name="Suffragium"


### PR DESCRIPTION
In case someone is not following proper setup of a project (e.g. me) and creates a game.cfg with a main_scene that does not exist, disable the game for loading and print an error in the console. Also some warnings are also handled now.

Looks like this if something is disabled:
![grafik](https://user-images.githubusercontent.com/833043/172909499-088caa3d-57ab-420b-b179-886c910d4853.png)
