### PR TITLE
Tool Script Windows - run GDScript Toolkit

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 # Auto detect text files and perform LF normalization
 * text=auto eol=lf
+# Except for bat files, which are Windows only files
+*.bat eol=crlf

--- a/tools/run_gd_script_toolkit.bat
+++ b/tools/run_gd_script_toolkit.bat
@@ -1,0 +1,4 @@
+cd ..
+gdformat game/
+gdlint game/
+pause

--- a/tools/run_gd_script_toolkit.bat
+++ b/tools/run_gd_script_toolkit.bat
@@ -1,4 +1,15 @@
+@title Run GDScript Toolkit
+@echo off
+rem *********************
+rem This Script runs gdformat and gdlint on all files in game folder.
+rem https://github.com/Scony/godot-gdscript-toolkit
+rem *********************
 cd ..
+echo --- Format ---
 gdformat game/
+echo.
+echo --- Lint ---
 gdlint game/
+echo.
+echo.
 pause


### PR DESCRIPTION
# Description
Added a .bat file for simpler use of the GDScript Toolkit.
Is not important, but maybe some folks want to have it.

## Type of change
- [x] Tooling (non breaking change that adds functionality to the workflow)

## Environment
- OS: Windows
