### PR TITLE
SortIt: Nerfed easy griefing

### DIFF
--- a/game/games/sortit/pedestal group.gd
+++ b/game/games/sortit/pedestal group.gd
@@ -53,8 +53,10 @@ func set_color(color: Color):
 
 func set_assigned_player(assigned_player: SortItPlayer):
 	_assigned_player = assigned_player
+	# Give each pedestal a reference to all players
+	var players = get_node("../../Players").get_children()
 	for pedestal in get_children():
-		pedestal.player = assigned_player
+		pedestal.set_players(players)
 
 
 func _ready():

--- a/game/games/sortit/players.gd
+++ b/game/games/sortit/players.gd
@@ -49,11 +49,14 @@ func spawn_players():
 		player.player_index = i
 		var player_color = player_colors[i]
 		player.set_color(player_color)
-		# Setup pedestals for player
-		player_pedestals.set_assigned_player(player)
+		# Set pedestals player color
 		player_pedestals.set_color(player_color)
 		# Only enable pedestals, that are assigned to a player
 		player_pedestals.enable()
+	# Assign the player to the pedestal once every player has been initialized
+	for i in range(player_count):
+		var player_pedestals = _pedestals.get_child(i)
+		player_pedestals.set_assigned_player(get_child(i))
 	set_player_colors_on_ground_plane()
 
 


### PR DESCRIPTION
# Description
This PR is a small change to the SortIt Mini game #34. It aims to nerf an issue that I have experienced when playing with others.

*The issue is*: Other players can easily grief other players, by just driving through the boxes on the pedestals. This can be done in about 1s, which is way too short, to lose all points at once.

The problem is **not** that players can steal boxes from other players (This is an indented part of the game), but that the game devolves into a game of griefing, once any player starts applying this tactic which forces other players to also apply this tactic, in order to have any chance of winning. This means that at the end of the game everyone ends up with 0 points and no one is happy.

*The solution*: When a box is on a pedestal **all** collisions with players are disabled. The only way to remove a box from a pedestal is, by using the magnets, which takes way more time than just colliding with it.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist
- [x] My code follows the general style guidelines of the project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particular where it is unclear
- [x] My changes generate no new warnings or errors
- [x] The project compiles and runs correctly
