### PR TITLE
Sort it: Fix player select screen and auto open help popup

### DIFF
--- a/game/games/sortit/ui/player_select.gd
+++ b/game/games/sortit/ui/player_select.gd
@@ -32,6 +32,11 @@ func get_display() -> bool:
 
 
 func set_get_input(do_get_input: bool):
+	# This check is needed, because the onready vars might not be initialized when the node is created
+	if not is_inside_tree():
+		_get_input = do_get_input
+		return
+
 	if do_get_input:
 		set_process_input(true)
 		self.add_stylebox_override("panel", get_input_style)
@@ -50,7 +55,12 @@ func get_get_input() -> bool:
 
 
 func _ready():
+	if Engine.is_editor_hint():
+		return
 	_player_text.text = name
+	# Update the state once all the onready nodes are initialized
+	set_get_input(_get_input)
+	set_display(_display)
 
 
 func _input(event):

--- a/game/games/sortit/ui/player_select.tscn
+++ b/game/games/sortit/ui/player_select.tscn
@@ -3,7 +3,7 @@
 [ext_resource path="res://games/sortit/ui/player_select.gd" type="Script" id=1]
 [ext_resource path="res://shared/fonts/roboto/roboto_black.ttf" type="DynamicFontData" id=2]
 
-[sub_resource type="StyleBoxEmpty" id=21]
+[sub_resource type="StyleBoxEmpty" id=23]
 
 [sub_resource type="StyleBoxFlat" id=20]
 draw_center = false
@@ -26,7 +26,7 @@ margin_right = 392.0
 margin_bottom = 247.0
 size_flags_horizontal = 3
 size_flags_vertical = 3
-custom_styles/panel = SubResource( 21 )
+custom_styles/panel = SubResource( 23 )
 script = ExtResource( 1 )
 get_input_style = SubResource( 20 )
 

--- a/game/games/sortit/ui/player_selector.gd
+++ b/game/games/sortit/ui/player_selector.gd
@@ -7,9 +7,17 @@ var _player_inputs = []
 onready var _players = $MarginContainer/VBoxContainer/MarginContainer/Players
 onready var _back_button: Button = $MarginContainer/VBoxContainer/Buttons/HBoxContainer/BackButton
 onready var _play_button: Button = $MarginContainer/VBoxContainer/Buttons/HBoxContainer2/PlayButton
+# Path is to long, but cannot cleanly be split into multiple lines to avoid line length limit
+# gdlint: ignore=max-line-length
+onready var _help_button: Button = $MarginContainer/VBoxContainer/HBoxContainer/HBoxContainer/HelpButton
 
 
 func _ready():
+	# Open help screen, if game has not been played yet
+	var game_data = GameManager.get_game_data()
+	if not game_data.has("played"):
+		_on_help_button_up()
+
 	for i in range(_players.get_child_count()):
 		var player_select = _players.get_children()[i]
 		if i != 0:
@@ -58,8 +66,21 @@ func _on_back_button_up():
 
 
 func _on_play_button_up():
+	# Mark game as played, to not show the help popup again by default
+	var game_data = GameManager.get_game_data()
+	if not game_data.has("played"):
+		game_data["played"] = true
+		GameManager.save_game_data()
+	# Emit the start_game signal with the configured controls to actually start the game
 	emit_signal("start_game", _player_inputs)
 
 
 func _on_help_button_up():
 	$HelpPopup.popup_centered_ratio(0.85)
+	$MarginContainer.modulate.a = 0.4
+	_help_button.disabled = true
+
+
+func _on_help_popup_hide():
+	$MarginContainer.modulate.a = 1.0
+	_help_button.disabled = false

--- a/game/games/sortit/ui/player_selector.gd
+++ b/game/games/sortit/ui/player_selector.gd
@@ -3,6 +3,7 @@ signal start_game(player_inputs)
 
 var _current_input_player_selctor_index = 0
 var _player_inputs = []
+var _has_been_played = true
 
 onready var _players = $MarginContainer/VBoxContainer/MarginContainer/Players
 onready var _back_button: Button = $MarginContainer/VBoxContainer/Buttons/HBoxContainer/BackButton
@@ -15,8 +16,9 @@ onready var _help_button: Button = $MarginContainer/VBoxContainer/HBoxContainer/
 func _ready():
 	# Open help screen, if game has not been played yet
 	var game_data = GameManager.get_game_data()
-	if not game_data.has("played"):
+	if not game_data.has("played") or game_data["played"] == false:
 		_on_help_button_up()
+		_has_been_played = false
 
 	for i in range(_players.get_child_count()):
 		var player_select = _players.get_children()[i]
@@ -68,7 +70,7 @@ func _on_back_button_up():
 func _on_play_button_up():
 	# Mark game as played, to not show the help popup again by default
 	var game_data = GameManager.get_game_data()
-	if not game_data.has("played"):
+	if not _has_been_played:
 		game_data["played"] = true
 		GameManager.save_game_data()
 	# Emit the start_game signal with the configured controls to actually start the game

--- a/game/games/sortit/ui/player_selector.tscn
+++ b/game/games/sortit/ui/player_selector.tscn
@@ -241,6 +241,7 @@ custom_constants/hseparation = 20
 columns = 2
 
 [node name="Player 1" parent="MarginContainer/VBoxContainer/MarginContainer/Players" instance=ExtResource( 2 )]
+get_input = true
 display = true
 
 [node name="Player 2" parent="MarginContainer/VBoxContainer/MarginContainer/Players" instance=ExtResource( 2 )]
@@ -305,3 +306,4 @@ size_flags_vertical = 3
 [connection signal="button_up" from="MarginContainer/VBoxContainer/HBoxContainer/HBoxContainer/HelpButton" to="." method="_on_help_button_up"]
 [connection signal="button_up" from="MarginContainer/VBoxContainer/Buttons/HBoxContainer/BackButton" to="." method="_on_back_button_up"]
 [connection signal="button_up" from="MarginContainer/VBoxContainer/Buttons/HBoxContainer2/PlayButton" to="." method="_on_play_button_up"]
+[connection signal="popup_hide" from="HelpPopup" to="." method="_on_help_popup_hide"]


### PR DESCRIPTION
# Description
This fixes an issue where the player select screen wouldn't show the "Press button to add" text, for the first player.

### Before:
![image](https://user-images.githubusercontent.com/34373974/177803407-71fdb049-3673-48ca-ab0f-472c97e5be33.png)
### After:
![image](https://user-images.githubusercontent.com/34373974/177803142-15312f27-2963-49a9-81f6-82b5a4c67343.png)


This PR also adds a feature: The Help screen will now automatically open, if the game has not been played before, ensuring that at least one player at least knows, that there is a help screen (Even better if they actually look at it properly).

This PR is motivated by the not so desirable user experience shown in Toms latest video of this game.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- Tooling (non-breaking change that adds functionality to the workflow)
- Breaking change (fix or feature that causes existing functionality to not work as expected)
# Checklist
- [x] My code follows the general style guidelines of the project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly where it is unclear
- [x] My changes generate no new warnings or errors
- [x] The project compiles and runs correctly
