### PR TITLE
Pixel Side Scroller - Core improvements

### DIFF
--- a/game/games/pixel_side_scroller/camera/camera.gd
+++ b/game/games/pixel_side_scroller/camera/camera.gd
@@ -1,0 +1,27 @@
+extends Camera2D
+
+var default_zoom: float = 0.4
+var default_size: Vector2 = Vector2(1024, 600)
+var target
+
+
+func _ready():
+	# warning-ignore:return_value_discarded
+	get_tree().get_root().connect("size_changed", self, "_on_resize")
+	_on_resize()
+
+
+func _process(_delta):
+	if is_instance_valid(target):
+		position = target.position
+
+
+func _on_resize():
+	var new_size: Vector2 = get_viewport_rect().size
+	var factor: Vector2 = Vector2.ZERO
+	factor.x = default_size.x / new_size.x
+	factor.y = default_size.y / new_size.y
+	if factor.x > factor.y:
+		zoom = Vector2(default_zoom * factor.x, default_zoom * factor.x)
+	else:
+		zoom = Vector2(default_zoom * factor.y, default_zoom * factor.y)

--- a/game/games/pixel_side_scroller/camera/camera.tscn
+++ b/game/games/pixel_side_scroller/camera/camera.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://games/pixel_side_scroller/camera/camera.gd" type="Script" id=1]
+
+[node name="Camera" type="Camera2D"]
+current = true
+zoom = Vector2( 0.4, 0.4 )
+smoothing_enabled = true
+script = ExtResource( 1 )

--- a/game/games/pixel_side_scroller/entitys/goal.tscn
+++ b/game/games/pixel_side_scroller/entitys/goal.tscn
@@ -3,9 +3,9 @@
 [ext_resource path="res://games/pixel_side_scroller/entitys/goal.gd" type="Script" id=1]
 
 [sub_resource type="RectangleShape2D" id=2]
+resource_local_to_scene = true
 
 [node name="Goal" type="Area2D"]
-position = Vector2( 115, -10 )
 script = ExtResource( 1 )
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]

--- a/game/games/pixel_side_scroller/entitys/help_trigger.gd
+++ b/game/games/pixel_side_scroller/entitys/help_trigger.gd
@@ -1,7 +1,8 @@
 tool
 extends Area2D
 
-export(Vector2) var trigger_size = Vector2(10, 10) setget _set_trigger_size
+export(int) var feature = PixelSideScrollerUtils.Features.MOVE
+export(Vector2) var trigger_size = Vector2(20, 20) setget _set_trigger_size
 var _triggered: bool = false
 onready var _main = get_tree().current_scene
 
@@ -11,10 +12,9 @@ func _set_trigger_size(new_size: Vector2):
 	$CollisionShape2D.shape.extents = new_size
 
 
-func _on_Goal_body_entered(body):
+func _on_HelpTrigger_body_entered(body):
 	if _triggered:
 		return
 	if body is KinematicBody2D and body.is_in_group("Player"):
-		body.disable()
 		_triggered = true
-		_main.goal_reached()
+		_main.ui.help_box.display(feature)

--- a/game/games/pixel_side_scroller/entitys/help_trigger.tscn
+++ b/game/games/pixel_side_scroller/entitys/help_trigger.tscn
@@ -1,0 +1,15 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://games/pixel_side_scroller/entitys/help_trigger.gd" type="Script" id=1]
+
+[sub_resource type="RectangleShape2D" id=1]
+resource_local_to_scene = true
+extents = Vector2( 20, 20 )
+
+[node name="HelpTrigger" type="Area2D"]
+script = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )
+
+[connection signal="body_entered" from="." to="." method="_on_HelpTrigger_body_entered"]

--- a/game/games/pixel_side_scroller/main.gd
+++ b/game/games/pixel_side_scroller/main.gd
@@ -1,35 +1,33 @@
 extends Node2D
 
-var current_map = null
 var player = null
-
-onready var camera = "Camera2D"
+onready var camera = $Camera
+onready var ui = $UI
+onready var map_manager = $MapManager
 
 
 func _ready():
-	load_map("map")
-	spawn_player()
-
-
-func load_map(name_name: String):
-	if current_map:
-		current_map.queue_free()
-	var new_map = load("res://games/pixel_side_scroller/maps/" + name_name + ".tscn").instance()
-	current_map = new_map
-	add_child(new_map)
+	map_manager.find_maps()
+# warning-ignore:return_value_discarded
+	map_manager.load_next_map()
 
 
 func spawn_player():
-	var spawn = current_map.get_node("Spawn")
-	if !is_instance_valid(spawn):
+	var spawn = map_manager.current_map.get_node("Spawn")
+	if not is_instance_valid(spawn):
 		return
-	if player:
-		player.queue_free()
-	var new_player = load("res://games/pixel_side_scroller/pawns/character/character.tscn").instance()
-	player = new_player
-	player.position = spawn.position
-	add_child(new_player)
+	if not player:
+		var new_player = load("res://games/pixel_side_scroller/pawns/character/character.tscn").instance()
+		player = new_player
+		player.position = spawn.position
+		camera.target = player
+		add_child(new_player)
+	else:
+		player.position = spawn.position
+	yield(get_tree(), "idle_frame")
+	player.enable()
 
 
 func goal_reached():
-	GameManager.end_game("Best Game Ever. 5/7 Rateing")
+	if not map_manager.load_next_map():
+		GameManager.end_game("Best Game Ever. 5/7 Rating")

--- a/game/games/pixel_side_scroller/main.tscn
+++ b/game/games/pixel_side_scroller/main.tscn
@@ -1,10 +1,16 @@
-[gd_scene load_steps=2 format=2]
+[gd_scene load_steps=5 format=2]
 
+[ext_resource path="res://games/pixel_side_scroller/ui/ui.tscn" type="PackedScene" id=1]
 [ext_resource path="res://games/pixel_side_scroller/main.gd" type="Script" id=2]
+[ext_resource path="res://games/pixel_side_scroller/maps/map_manager.gd" type="Script" id=3]
+[ext_resource path="res://games/pixel_side_scroller/camera/camera.tscn" type="PackedScene" id=4]
 
 [node name="Main" type="Node2D"]
 script = ExtResource( 2 )
 
-[node name="Camera2D" type="Camera2D" parent="."]
-current = true
-zoom = Vector2( 0.4, 0.4 )
+[node name="UI" parent="." instance=ExtResource( 1 )]
+
+[node name="MapManager" type="Node" parent="."]
+script = ExtResource( 3 )
+
+[node name="Camera" parent="." instance=ExtResource( 4 )]

--- a/game/games/pixel_side_scroller/maps/map2.tscn
+++ b/game/games/pixel_side_scroller/maps/map2.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=12 format=2]
+[gd_scene load_steps=10 format=2]
 
 [ext_resource path="res://shared/fonts/press_start2p/press_start2p_regular.ttf" type="DynamicFontData" id=1]
 [ext_resource path="res://games/pixel_side_scroller/entitys/goal.tscn" type="PackedScene" id=2]
@@ -13,40 +13,36 @@ font_data = ExtResource( 1 )
 extents = Vector2( 7, 44.5 )
 
 [sub_resource type="RectangleShape2D" id=5]
-extents = Vector2( 89, 4.5 )
+extents = Vector2( 201, 4.5 )
 
 [sub_resource type="DynamicFont" id=4]
 size = 8
 font_data = ExtResource( 1 )
 
 [sub_resource type="RectangleShape2D" id=7]
-extents = Vector2( 73.5, 6.5 )
-
-[sub_resource type="RectangleShape2D" id=8]
-extents = Vector2( 5.5, 12 )
-
-[sub_resource type="RectangleShape2D" id=9]
-extents = Vector2( 38.5811, 5 )
+extents = Vector2( 9, 9 )
 
 [node name="Map" type="Node2D"]
 
 [node name="Spawn" parent="." instance=ExtResource( 3 )]
 
 [node name="Goal" parent="." instance=ExtResource( 2 )]
-position = Vector2( 117, -15 )
-trigger_size = Vector2( 10, 15 )
+position = Vector2( 117, -10 )
 
 [node name="Label2" type="Label" parent="Goal"]
 margin_left = -14.0
-margin_top = -36.0
+margin_top = -42.0
 margin_right = 170.0
-margin_bottom = 16.0
+margin_bottom = 10.0
 custom_fonts/font = SubResource( 3 )
 text = "Goal
 ^
 |
 |
 |"
+__meta__ = {
+"_edit_lock_": true
+}
 
 [node name="Ground" type="StaticBody2D" parent="."]
 __meta__ = {
@@ -68,7 +64,7 @@ __meta__ = {
 }
 
 [node name="CollisionShape2D2" type="CollisionShape2D" parent="Ground"]
-position = Vector2( -108, 5.5 )
+position = Vector2( 4, 5.5 )
 shape = SubResource( 5 )
 __meta__ = {
 "_edit_lock_": true
@@ -80,56 +76,7 @@ margin_top = -8.5
 margin_right = 198.0
 margin_bottom = 43.5
 custom_fonts/font = SubResource( 4 )
-text = "----------------------"
-align = 1
-__meta__ = {
-"_edit_lock_": true
-}
-
-[node name="CollisionShape2D4" type="CollisionShape2D" parent="Ground"]
-position = Vector2( 127.5, 6.5 )
-shape = SubResource( 7 )
-__meta__ = {
-"_edit_lock_": true
-}
-
-[node name="Label3" type="Label" parent="Ground/CollisionShape2D4"]
-margin_left = -199.5
-margin_top = -8.5
-margin_right = 200.5
-margin_bottom = 43.5
-custom_fonts/font = SubResource( 4 )
-text = "-------------------"
-align = 1
-
-[node name="CollisionShape2D5" type="CollisionShape2D" parent="Ground"]
-position = Vector2( 59.5, 15 )
-shape = SubResource( 8 )
-
-[node name="Label3" type="Label" parent="Ground/CollisionShape2D5"]
-margin_left = -205.5
-margin_top = -14.0
-margin_right = 194.5
-margin_bottom = 38.0
-custom_fonts/font = SubResource( 4 )
-text = "|
-|
-|"
-align = 1
-
-[node name="CollisionShape2D6" type="CollisionShape2D" parent="Ground"]
-position = Vector2( 16, 18 )
-rotation = 0.329099
-shape = SubResource( 9 )
-
-[node name="Label3" type="Label" parent="Ground/CollisionShape2D6"]
-margin_left = -202.0
-margin_top = -8.5
-margin_right = 198.0
-margin_bottom = 43.5
-custom_fonts/font = SubResource( 4 )
-text = "----------"
-align = 1
+text = "--------------------------------------------------"
 __meta__ = {
 "_edit_lock_": true
 }
@@ -137,7 +84,33 @@ __meta__ = {
 [node name="HelpTriggerMove" parent="." instance=ExtResource( 4 )]
 position = Vector2( -95, -20 )
 
+[node name="HelpTriggerMove2" parent="." instance=ExtResource( 4 )]
+position = Vector2( -175, -20 )
+
 [node name="HelpTriggerJump" parent="." instance=ExtResource( 4 )]
-position = Vector2( 13, -13 )
+position = Vector2( 23, -20 )
 feature = 1
-trigger_size = Vector2( 40, 30 )
+
+[node name="StaticBody2D" type="StaticBody2D" parent="."]
+position = Vector2( 49, -8 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="StaticBody2D"]
+position = Vector2( 0, -1 )
+shape = SubResource( 7 )
+__meta__ = {
+"_edit_lock_": true
+}
+
+[node name="Label3" type="Label" parent="StaticBody2D"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+margin_left = -12.0
+margin_top = -10.0
+margin_right = 14.0
+margin_bottom = 10.0
+custom_fonts/font = SubResource( 4 )
+text = "|-|
+| |"
+__meta__ = {
+"_edit_lock_": true
+}

--- a/game/games/pixel_side_scroller/maps/map_manager.gd
+++ b/game/games/pixel_side_scroller/maps/map_manager.gd
@@ -1,0 +1,60 @@
+extends Node
+
+var current_map = null
+var _maps: Array = []
+onready var _main = get_tree().current_scene
+
+
+func find_maps():
+	var path: String = "res://games/pixel_side_scroller/maps"
+	var map_names: Array = []
+	var dir: Directory = Directory.new()
+	if dir.open(path) != OK:
+		push_error("Could not open directory %s" % path)
+		return
+	if dir.list_dir_begin(true, true) != OK:
+		push_error("Could list_dir_begin directory %s" % path)
+		return
+	while true:
+		var file: String = dir.get_next()
+		if file == "":
+			break
+		if file.begins_with("."):
+			continue
+		if not file.ends_with(".tscn"):
+			continue
+		map_names.append(file.split(".")[0])
+	dir.list_dir_end()
+	randomize()
+	map_names.shuffle()
+	_maps = map_names
+
+
+func load_next_map() -> bool:
+	if _maps.size() == 0:
+		return false
+	var valid_map: bool = _load_map(_maps[0])
+	_maps.pop_front()
+	if not valid_map:
+		return load_next_map()
+	_main.spawn_player()
+	return true
+
+
+func _load_map(name_name: String) -> bool:
+	if current_map:
+		current_map.queue_free()
+	var new_map_load = load("res://games/pixel_side_scroller/maps/" + name_name + ".tscn")
+	if not new_map_load:
+		return false
+	var new_map = new_map_load.instance()
+	# Check for spawn and goal
+	if (
+		not is_instance_valid(new_map.get_node("Spawn"))
+		or not is_instance_valid(new_map.get_node("Goal"))
+	):
+		push_error("ERROR: map '%s' is not valid! missing spawn or goal" % name_name)
+		return false
+	current_map = new_map
+	call_deferred("add_child", new_map)
+	return true

--- a/game/games/pixel_side_scroller/pawns/movement.gd
+++ b/game/games/pixel_side_scroller/pawns/movement.gd
@@ -1,18 +1,19 @@
 extends Node
 
-var jumped: bool = false
-var jump_curve: Curve = load("res://games/pixel_side_scroller/pawns/jump_curve.tres")
-var jump_timer: Timer = Timer.new()
-
 var jumping: bool = false
 var direction: Vector2 = Vector2.ZERO setget , _get_direction
 var velocity: Vector2 = Vector2.ZERO
 
-onready var pawn = get_parent()
+var _jumped: bool = false
+var _jump_curve: Curve = load("res://games/pixel_side_scroller/pawns/jump_curve.tres")
+var _jump_timer: Timer = Timer.new()
+
+onready var _main = get_tree().current_scene
+onready var _pawn = get_parent()
 
 
 func _get_direction():
-	return Vector2(pawn.right - pawn.left, 0)
+	return Vector2(_pawn.right - _pawn.left, 0)
 
 
 func _ready():
@@ -23,42 +24,46 @@ func _ready():
 func do(delta):
 	_jump(delta)
 	# Gravity
-	if pawn.is_on_floor() and not jumping:
+	if _pawn.is_on_floor() and not jumping:
 		velocity.y = 0
-	elif not pawn.is_on_floor() and not jumping:
-		velocity.y = min(pawn.max_fall_speed, velocity.y + (pawn.gravity + delta))
+	elif not _pawn.is_on_floor() and not jumping:
+		velocity.y = min(_pawn.max_fall_speed, velocity.y + (_pawn.gravity + delta))
 
-	velocity.x = _get_direction().x * pawn.speed
+	var input_direction: float = _get_direction().x
+	if input_direction != 0.0:
+		_main.ui.help_box.used_feature(PixelSideScrollerUtils.Features.MOVE)
+	velocity.x = input_direction * _pawn.speed
 
 
 # Handle jumps
 func _jump(delta):
 	# Reset state variables on "jump release"
-	if not pawn.jump and jumped:
-		jumped = false
+	if not _pawn.jump and _jumped:
+		_jumped = false
 		jumping = false
 	# Handle "hold jump" in air
-	if not pawn.is_on_floor():
-		if pawn.jump and jumped:
+	if not _pawn.is_on_floor():
+		if _pawn.jump and _jumped:
 			var curve_point: float = (
-				(jump_timer.wait_time - jump_timer.time_left)
-				/ jump_timer.wait_time
+				(_jump_timer.wait_time - _jump_timer.time_left)
+				/ _jump_timer.wait_time
 			)
 			if curve_point < 1.0:
-				var curve_interpolate_value: float = jump_curve.interpolate(curve_point)
-				velocity.y += (-pawn.jump_force * delta) * curve_interpolate_value
+				var curve_interpolate_value: float = _jump_curve.interpolate(curve_point)
+				velocity.y += (-_pawn.jump_force * delta) * curve_interpolate_value
 			else:
 				jumping = false
 	# Do "jump" if on the floor
-	if pawn.is_on_floor() and pawn.jump and not jumped:
+	if _pawn.is_on_floor() and _pawn.jump and not _jumped:
 		jumping = true
-		jumped = true
-		velocity.y = -pawn.jump_force
-		jump_timer.start()
+		_jumped = true
+		velocity.y = -_pawn.jump_force
+		_jump_timer.start()
+		_main.ui.help_box.used_feature(PixelSideScrollerUtils.Features.JUMP)
 
 
 func _init_jump_timer():
-	jump_timer.one_shot = true
-	jump_timer.wait_time = pawn.jump_time
-	jump_timer.name = "JumpTimer"
-	add_child(jump_timer)
+	_jump_timer.one_shot = true
+	_jump_timer.wait_time = _pawn.jump_time
+	_jump_timer.name = "JumpTimer"
+	add_child(_jump_timer)

--- a/game/games/pixel_side_scroller/pawns/pawn.gd
+++ b/game/games/pixel_side_scroller/pawns/pawn.gd
@@ -17,3 +17,11 @@ func _physics_process(delta):
 	movement.do(delta)
 	# warning-ignore:return_value_discarded
 	move_and_slide(movement.velocity, Vector2.UP)
+
+
+func disable():
+	$CollisionShape2D.set_deferred("disabled", true)
+
+
+func enable():
+	$CollisionShape2D.disabled = false

--- a/game/games/pixel_side_scroller/pawns/pawn.tscn
+++ b/game/games/pixel_side_scroller/pawns/pawn.tscn
@@ -6,7 +6,7 @@
 
 [sub_resource type="RectangleShape2D" id=1]
 
-[node name="Pawn" type="KinematicBody2D"]
+[node name="Pawn" type="KinematicBody2D" groups=["Player"]]
 script = ExtResource( 1 )
 
 [node name="Input" type="Node" parent="."]

--- a/game/games/pixel_side_scroller/ui/help_box.gd
+++ b/game/games/pixel_side_scroller/ui/help_box.gd
@@ -1,0 +1,28 @@
+extends Control
+
+var _feature: int = PixelSideScrollerUtils.Features.MOVE
+var _feature_triggered: Array = []
+
+
+func _init() -> void:
+	hide()
+	# Init _feature_triggered
+	for _i in range(PixelSideScrollerUtils.Features.size()):
+		_feature_triggered.append(false)
+
+
+func display(feature: int) -> void:
+	_feature = feature
+	# Dont show help box if feature was already shown this run
+	if _feature_triggered[_feature]:
+		return
+	# Show help box
+	_feature = feature
+	$TabContainer.current_tab = _feature
+	_feature_triggered[_feature] = true
+	show()
+
+
+func used_feature(used_feature: int) -> void:
+	if visible and _feature == used_feature:
+		hide()

--- a/game/games/pixel_side_scroller/ui/help_box.tscn
+++ b/game/games/pixel_side_scroller/ui/help_box.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=6 format=2]
+
+[ext_resource path="res://games/pixel_side_scroller/ui/help_box.gd" type="Script" id=1]
+[ext_resource path="res://shared/fonts/press_start2p/press_start2p_regular.ttf" type="DynamicFontData" id=2]
+
+[sub_resource type="StyleBoxEmpty" id=1]
+
+[sub_resource type="DynamicFont" id=2]
+size = 8
+font_data = ExtResource( 2 )
+
+[sub_resource type="DynamicFont" id=3]
+size = 8
+font_data = ExtResource( 2 )
+
+[node name="HelpBox" type="Control"]
+margin_right = 200.0
+margin_bottom = 200.0
+grow_horizontal = 0
+script = ExtResource( 1 )
+
+[node name="TabContainer" type="TabContainer" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+size_flags_vertical = 3
+custom_styles/panel = SubResource( 1 )
+tabs_visible = false
+
+[node name="MOVE" type="Control" parent="TabContainer"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Label" type="Label" parent="TabContainer/MOVE"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_fonts/font = SubResource( 2 )
+text = "press <A> or <D> to move"
+align = 1
+valign = 1
+
+[node name="JUMP" type="Control" parent="TabContainer"]
+visible = false
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="Label" type="Label" parent="TabContainer/JUMP"]
+anchor_right = 1.0
+anchor_bottom = 1.0
+custom_fonts/font = SubResource( 3 )
+text = "press <SPACE> to jump"
+align = 1
+valign = 1

--- a/game/games/pixel_side_scroller/ui/ui.gd
+++ b/game/games/pixel_side_scroller/ui/ui.gd
@@ -1,0 +1,3 @@
+extends CanvasLayer
+
+onready var help_box = $Control/HelpBox

--- a/game/games/pixel_side_scroller/ui/ui.tscn
+++ b/game/games/pixel_side_scroller/ui/ui.tscn
@@ -1,0 +1,19 @@
+[gd_scene load_steps=3 format=2]
+
+[ext_resource path="res://games/pixel_side_scroller/ui/ui.gd" type="Script" id=1]
+[ext_resource path="res://games/pixel_side_scroller/ui/help_box.tscn" type="PackedScene" id=2]
+
+[node name="UI" type="CanvasLayer"]
+script = ExtResource( 1 )
+
+[node name="Control" type="Control" parent="."]
+anchor_right = 1.0
+anchor_bottom = 1.0
+
+[node name="HelpBox" parent="Control" instance=ExtResource( 2 )]
+anchor_left = 1.0
+anchor_right = 1.0
+margin_left = -216.0
+margin_top = 16.0
+margin_right = -16.0
+margin_bottom = 216.0

--- a/game/games/pixel_side_scroller/utils.gd
+++ b/game/games/pixel_side_scroller/utils.gd
@@ -1,0 +1,3 @@
+class_name PixelSideScrollerUtils
+
+enum Features { MOVE, JUMP }

--- a/game/project.godot
+++ b/game/project.godot
@@ -9,6 +9,11 @@
 config_version=4
 
 _global_script_classes=[ {
+"base": "Reference",
+"class": "PixelSideScrollerUtils",
+"language": "GDScript",
+"path": "res://games/pixel_side_scroller/utils.gd"
+}, {
 "base": "RigidBody",
 "class": "SortItBox",
 "language": "GDScript",
@@ -24,12 +29,13 @@ _global_script_classes=[ {
 "language": "GDScript",
 "path": "res://games/sortit/player.gd"
 }, {
-"base": "Reference",
+"base": "MarginContainer",
 "class": "SortItRoot",
 "language": "GDScript",
 "path": "res://games/sortit/sort_it.gd"
 } ]
 _global_script_class_icons={
+"PixelSideScrollerUtils": "",
 "SortItBox": "",
 "SortItPedestal": "",
 "SortItPlayer": "",


### PR DESCRIPTION
# Description
Improves core mechanics of pixel side scroller.
- Camera response to window resize and follows the player.
- Loads all maps from the /maps folder and shuffles them.
After all level are complied the game ends.
- Added HelpTriggers to show control info in HUD
They should be placed before each obstacle, because each map could be the first someone is playing.

![image](https://user-images.githubusercontent.com/84922125/178283420-a9911ffa-7b84-4855-83e2-d4fdd0951c74.png)
---
## Type of change
- [x] Bug fix (non breaking change that fixes an issue)
- [x] New feature (non breaking change that adds functionality)
