### PR TITLE
SortIt: Fixed help screen related bugs #69

### DIFF
--- a/game/games/sortit/ui/player_selector.gd
+++ b/game/games/sortit/ui/player_selector.gd
@@ -1,19 +1,26 @@
 extends PanelContainer
 signal start_game(player_inputs)
 
+const HELP_POPUP_BACKGROUND_BRIGHTNESS = 0.4
+
 var _current_input_player_selctor_index = 0
 var _player_inputs = []
 var _has_been_played = true
+var _help_popup_just_closed = false
+var _selectors_get_input_state_copy = []
 
+onready var _main_content_container: MarginContainer = $MarginContainer
 onready var _players = $MarginContainer/VBoxContainer/MarginContainer/Players
 onready var _back_button: Button = $MarginContainer/VBoxContainer/Buttons/HBoxContainer/BackButton
 onready var _play_button: Button = $MarginContainer/VBoxContainer/Buttons/HBoxContainer2/PlayButton
+onready var _help_popup: Popup = $HelpPopup
 # Path is to long, but cannot cleanly be split into multiple lines to avoid line length limit
 # gdlint: ignore=max-line-length
 onready var _help_button: Button = $MarginContainer/VBoxContainer/HBoxContainer/HBoxContainer/HelpButton
 
 
 func _ready():
+	set_process_input(false)
 	# Open help screen, if game has not been played yet
 	var game_data = GameManager.get_game_data()
 	if not game_data.has("played") or game_data["played"] == false:
@@ -25,6 +32,26 @@ func _ready():
 		if i != 0:
 			player_select.set_process_input(false)
 		player_select.connect("got_input", self, "_on_player_select_got_input")
+
+
+# This function is only enabled if the help popup is open
+func _input(event):
+	# Close Help popup, when escape is pressed and prevent pause menu from opening
+	if event is InputEventKey and event.physical_scancode == KEY_ESCAPE:
+		_help_popup.visible = false
+		_main_content_container.modulate.a = 1.0
+		call_deferred("_on_help_popup_hide_and_mouse_release")
+		get_tree().set_input_as_handled()
+	# Call _on_help_popup_hide_and_mouse_release on mouse release when the popup is just closed
+	elif (
+		event is InputEventMouseButton
+		and event.button_index == BUTTON_LEFT
+		and not event.pressed
+		and _help_popup_just_closed
+	):
+		_help_popup_just_closed = false
+		set_process_input(false)
+		call_deferred("_on_help_popup_hide_and_mouse_release")
 
 
 func _on_player_select_got_input(input_type: Array):
@@ -62,8 +89,9 @@ func _on_back_button_up():
 	_current_input_player_selctor_index -= 1
 	var old_selector = _players.get_child(_current_input_player_selctor_index)
 	old_selector.get_input = true
-	# Hide back button, if at start
+	# Hide back button and disable play button, if at start
 	if _current_input_player_selctor_index == 0:
+		_play_button.disabled = true
 		_back_button.hide()
 
 
@@ -78,11 +106,34 @@ func _on_play_button_up():
 
 
 func _on_help_button_up():
-	$HelpPopup.popup_centered_ratio(0.85)
-	$MarginContainer.modulate.a = 0.4
+	_help_popup.popup_centered_ratio(0.85)
+	_main_content_container.modulate.a = HELP_POPUP_BACKGROUND_BRIGHTNESS
+	set_process_input(true)
+	# Disable buttons, so that they can not be accidentally pressed, if the popup is open
 	_help_button.disabled = true
+	_play_button.disabled = true
+	_back_button.disabled = true
+	# Disable input processing on all children (To avoid registering players, while in the help menu)
+	# Before disabling the input processing, remember the input state of each player select
+	_selectors_get_input_state_copy.clear()
+	for i in range(_players.get_child_count()):
+		var player_select = _players.get_children()[i]
+		_selectors_get_input_state_copy.push_back(player_select.get_input)
+		player_select.set_process_input(false)
 
 
 func _on_help_popup_hide():
-	$MarginContainer.modulate.a = 1.0
+	_main_content_container.modulate.a = 1.0
+	# Call _on_help_popup_hide_and_mouse_release on next mouse release
+	_help_popup_just_closed = true
+
+
+func _on_help_popup_hide_and_mouse_release():
+	# Re enable buttons
 	_help_button.disabled = false
+	_play_button.disabled = _current_input_player_selctor_index == 0
+	_back_button.disabled = false
+	# Enable processing on the correct children again
+	# (Based on what the input state was before the popup was open)
+	for i in range(_players.get_child_count()):
+		_players.get_children()[i].set_process_input(_selectors_get_input_state_copy[i])


### PR DESCRIPTION
# Description
This change fixes the bugs mentioned in the issue #69 and some others that I found:
- Players can no longer be added while the help screen is open.
- Buttons (Back, Play) can no longer be clicked while the help screen is open (and also when the help screen was just closed, but the mouse is still pressed).
- Pause menu won't open anymore while the help screen is open.
- Hitting "Escape" while the help screen is open, will now close it.
- Play button will now be disabled, when hitting the back button, when only one player was selected

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

# Checklist
- [x] My code follows the general style guidelines of the project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly where it is unclear
- [x] My changes generate no new warnings or errors
- [x] The project compiles and runs correctly
