### PR TITLE
Fixed compatibility with Godot 3.5

### DIFF
--- a/game/app/end_game_menu/end_game_menu.gd
+++ b/game/app/end_game_menu/end_game_menu.gd
@@ -25,7 +25,7 @@ func _input(event: InputEvent):
 		get_tree().set_input_as_handled()
 
 
-func show(text, game_config):
+func open(text, game_config):
 	_game_config = game_config
 
 	if text == null:
@@ -36,16 +36,16 @@ func show(text, game_config):
 	get_tree().paused = true
 
 
-func _close():
+func close():
 	get_tree().paused = false
 	queue_free()
 
 
 func _on_ButtonRestart_pressed():
-	_close()
+	close()
 	GameManager.load_game(_game_config)
 
 
 func _on_ButtonMenu_pressed():
-	_close()
+	close()
 	Utils.change_scene(GameManager.MENU_PATH)

--- a/game/app/singleton/game_manager.gd
+++ b/game/app/singleton/game_manager.gd
@@ -66,7 +66,7 @@ func end_game(message = null, score = null, show_end_game_menu: bool = true):
 	if show_end_game_menu:
 		var end_game_menu = res_end_game_menu.instance()
 		get_tree().get_root().add_child(end_game_menu)
-		end_game_menu.show(message, _current_game_config)
+		end_game_menu.open(message, _current_game_config)
 	else:
 		Utils.change_scene(MENU_PATH)
 

--- a/game/translations/tr.csv
+++ b/game/translations/tr.csv
@@ -39,7 +39,7 @@ T_LAST_PLAYED,Zuletzt gespielt,Last played
 T_PAUSED,PAUSIERT,PAUSED
 T_GAME_ENDED,Spiel vorbei,game over
 T_RESUME,Fortsetzen,Resume
-T_RESTART,Neustarten,Restart
+T_RESTART,Neustart,Restart
 T_BACK_TO_MENU,Zurück zum Menü,Back to menu
 T_SECOND,Sekunde,second
 T_SECONDS,Sekunden,seconds


### PR DESCRIPTION
# Description
Godot 3.5 introduces new members `show()` and `hide()` for `CanvasLayer` conflicting with the end game menu, since it provides a method `show()` with different signature.

## Type of change
- [x] Bug fix (non breaking change that fixes an issue)

## Testing
Without these changes the project won't run under Godot 3.5 since API changes cause conflicting function signatures.

# Checklist
- [x] My code follows the general style guidelines of the project
- [x] I have perfomed a self-review of my code
- [x] I have commented my code, particulary where it is unclear
- [x] My changes generate no new warnings or errors
- [x] The project compiles and runs correctly
