### PR TITLE
Allow "fast path" for critical PRs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ If you want to add a feature or fix a bug. Pull Requests are the way to go. Try 
 #### REQUIRED
 
 - Follow the [GDScript style guide](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#gdscript-style-guide)
-- Use [Scony"s godot gdscript tollkit](https://github.com/Scony/godot-gdscript-toolkit/) to validate the Pull Request
+- Use [Scony's godot gdscript tollkit](https://github.com/Scony/godot-gdscript-toolkit/) to validate the Pull Request
 
 #### RECOMMENDED
 
@@ -31,7 +31,9 @@ If you want to add a feature or fix a bug. Pull Requests are the way to go. Try 
 
 ## How to Vote
 
-Place a :+1: or :-1: emoji on the initial post of an pull request. When the merge conditions are met, the pull request will be merged.
+Place a :+1: or :-1: emoji on the initial post of a pull request.
+If you're creating a PR to fix a blocking issue that currently breaks the project, i.e. a critical fix that shouldn't be delayed, use the :rocket: emoji.
+Once the merge conditions are met, the pull request can be merged.
 
 ## Merge pull request conditions
 
@@ -39,6 +41,7 @@ If one of them is true, the PR will me merged.
 
 - **Last commit is 24h or older** and **has more than 10 votes** and **75% positive votes**
 - **Last commit is 72h or older** and **75% positive votes**
+- **PR fixes a blocking issue** that prevents the main branch from editing/building/running (e.g. due to engine changes) and has at least **2 :rocket: votes**, excluding the author
 
 ## Close pull request without merging conditions
 


### PR DESCRIPTION
This resolves #79 by allowing the use of a new voting option, :rocket:, to bypass the arbitrary time limit in case fixes are necessary for the project to be opened or built when checked out with the latest version of Godot.

This should rarely be used, mostly in case incompatibilities slip through or are introduced, e.g. due to script changes shadowing custom functions.